### PR TITLE
Fix/argument value parsing

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -44,7 +44,7 @@ module.exports = function(db, config, cache) {
     });
   };
 
-  repl.context.get = 
+  repl.context.get =
   repl.context.GET = function(opts, callback) {
 
     if (!opts) {
@@ -60,7 +60,7 @@ module.exports = function(db, config, cache) {
     });
   };
 
-  repl.context.put = 
+  repl.context.put =
   repl.context.PUT = function(opts, callback) {
 
     var args = opts.rest.split(/\s+/);
@@ -80,7 +80,7 @@ module.exports = function(db, config, cache) {
       }
     }
 
-    if (!config.valueEncoding || 
+    if (!config.valueEncoding ||
         config.valueEncoding == 'json')  {
       try {
         val = JSON.parse(val);
@@ -101,7 +101,7 @@ module.exports = function(db, config, cache) {
 
   repl.context.rm =
   repl.context.del =
-  repl.context.RM = 
+  repl.context.RM =
   repl.context.DEL = function(opts, callback) {
 
     callback = callback || print;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -65,7 +65,8 @@ module.exports = function(db, config, cache) {
 
     var args = opts.rest.split(/\s+/);
     var key = args[0];
-    var val = args[1];
+    args.shift();
+    var val = args.join(' ');
 
     if (!val || !key) {
       return 'key and value required';


### PR DESCRIPTION
    Due to the fact that arguments were being parsed based on splitting the
    line at spaces, any values that included spaces would be split apart and
    only the first piece would be included. If the value contained JSON
    this would result in a malformed JSON string which resulted in syntax
    errors.

### To test
 - Create a new levelDb database and connect to it or connect to an existing one using lev.
 - Create a new key (or ensure a key exists that you can safely edit.
 - Update the value for the key to a JSON object that includes some spaces:
  - `put [mykey] "{\"test\": \"this is a test\"}"`
 - Ensure the put succeeds and does not throw an error.
 - Ensure the value is correct after getting the value of the key.